### PR TITLE
Ignore Supabase setup files and swap icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@ dist-ssr
 *.local
 CLAUDE.md
 .env
+
+# Setup/reference files (not for repo)
+SUPABASE-SETUP.md
+supabase-setup.sql
+supabase-setup-accounts.sql
+placanje.png
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ import {
   AlertCircle,
   Share2,
   History,
-  Plus,
+  Save,
   Trash2,
   ArrowLeftRight,
 } from "lucide-react";
@@ -846,7 +846,7 @@ const App: React.FC = () => {
                 className="p-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
                 title="Sačuvaj trenutnu uplatnicu"
               >
-                <Plus size={18} />
+                <Save size={18} />
               </button>
             </div>
 


### PR DESCRIPTION
Add setup/reference files to .gitignore so local setup artifacts are not committed. In src/App.tsx replace the Plus icon import/usage with Save from lucide-react for the save button.
<img width="966" height="369" alt="Screenshot 2026-03-22 at 5 34 12 PM" src="https://github.com/user-attachments/assets/888d4e0c-d7c4-4176-b921-5028dd91d57d" />